### PR TITLE
Fix padding - Was inheriting padding from two styles

### DIFF
--- a/accordion-collapse.js
+++ b/accordion-collapse.js
@@ -31,12 +31,14 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-accordion-collapse">
 			}
 			:host([icon-has-padding]) d2l-icon {
 				padding-left: 1.25rem;
+				padding-right: 0;
 			}
 			:host([icon-has-padding][dir="rtl"]) d2l-icon {
 				padding-left: 0;
 				padding-right: 1.25rem;
 			}
 			:host([flex][icon-has-padding]) d2l-icon {
+				padding-left: 0;
 				padding-right: 1.25rem;
 			}
 			:host([flex][icon-has-padding][dir="rtl"]) d2l-icon {


### PR DESCRIPTION
Was getting padding on left and right of the button - Only need/want it on one side.
![image](https://user-images.githubusercontent.com/17279735/82508062-ed66c880-9ad1-11ea-92e8-1cf18fe09fb6.png)

--> icon-has-padding is only used on Awards Leaderboard that hasn't been released to clients yet.