### PR TITLE
Add functionality to capture focus and blur of trigger in parent component

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ npm install @brightspace-ui-labs/accordion
 * noIcons - hide the expand/collapse icon
 * opened - container is opened by default. Do not use this attribute when inside the **d2l-labs-accordion** as the **d2l-labs-accordion** does not monitor opened state of the items at the start. In this case, use `selected` or `selectedValue` **d2l-labs-accordion** attributes instead.
 * disabled - container cannot be expanded or collapsed
+* disable-default-trigger-focus - disables the default outline added by browsers on trigger focus so custom styles can be added to the component on focus
 * headerBorder - show a border between the header and the summary/content
 * icon-has-padding - adds padding on one side of the icon.
   * When used with 'flex' attribute, the padding will be to the right. (Opposite for RTL)
   * Without 'flex' attribute, the padding will be on the left. (Opposite for RTL)
-* disable-default-trigger-focus - disables the default outline added by browsers on trigger focus so custom styles can be added to the component on focus
 
 #### Slots:
 * header - content to display under the title

--- a/README.md
+++ b/README.md
@@ -27,22 +27,23 @@ npm install @brightspace-ui-labs/accordion
 ```
 
 ## Polymer components:
-### **d2l-labs-accordion** - accordion panel. 
+### **d2l-labs-accordion** - accordion panel.
 #### Attributes:
 * multi - allows multiple collapsibles to be opened at the same time
 * selected - used only if `multi` is disabled. sets item index to be opened by default
 * selectedValue - used only if `multi` is set. Sets array of indexes for the items to be opened by default
 * autoClose - expanding any **d2l-labs-accordion-collapse** child (except those that are disabled) will automatically close other opened children.
-### **d2l-labs-accordion-collapse** - accordion component. 
+### **d2l-labs-accordion-collapse** - accordion component.
 #### Attributes:
 * flex - adjust component to the parent width
 * noIcons - hide the expand/collapse icon
 * opened - container is opened by default. Do not use this attribute when inside the **d2l-labs-accordion** as the **d2l-labs-accordion** does not monitor opened state of the items at the start. In this case, use `selected` or `selectedValue` **d2l-labs-accordion** attributes instead.
 * disabled - container cannot be expanded or collapsed
 * headerBorder - show a border between the header and the summary/content
-* icon-has-padding - adds padding on one side of the icon. 
+* icon-has-padding - adds padding on one side of the icon.
   * When used with 'flex' attribute, the padding will be to the right. (Opposite for RTL)
   * Without 'flex' attribute, the padding will be on the left. (Opposite for RTL)
+* disable-default-trigger-focus - disables the default outline added by browsers on trigger focus so custom styles can be added to the component on focus
 
 #### Slots:
 * header - content to display under the title

--- a/accordion-collapse.js
+++ b/accordion-collapse.js
@@ -90,7 +90,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-accordion-collapse">
 			}
 		</style>
 
-		<a href="javascript:void(0)" id="trigger" on-click="toggle" aria-controls="collapse" role="button" data-border$="[[headerBorder]]" on-focus="_triggerFocus" on-blur="_triggerBlur">
+		<a href="javascript:void(0)" id="trigger" aria-controls="collapse" role="button" data-border$="[[headerBorder]]" on-blur="_triggerBlur" on-click="toggle" on-focus="_triggerFocus">
 			<div class="collapse-title" title="[[label]]">[[title]][[label]]<slot name="header"></slot>
 			</div>
 			<template is="dom-if" if="[[!noIcons]]">
@@ -202,6 +202,14 @@ Polymer({
 			value: false
 		},
 		/**
+		 * Whether or not to disable default focus styles
+		 */
+		disableDefaultTriggerFocus: {
+			type: Boolean,
+			reflectToAttribute: true,
+			value: false
+		},
+		/**
 		 * Listener for state changes.
 		 */
 		_boundListener: {
@@ -214,15 +222,7 @@ Polymer({
 			type: String,
 			reflectToAttribute: true,
 			value: 'closed'
-		},
-		/**
-		 * Whether or not to disable default focus styles
-		 */
-		disableDefaultTriggerFocus: {
-			type: Boolean,
-			reflectToAttribute: true,
-			value: false
-		},
+		}
 	},
 	ready: function() {
 		this._boundListener = this._onStateChanged.bind(this);
@@ -278,10 +278,10 @@ Polymer({
 		}
 	},
 	_triggerFocus: function() {
-		this.fire('d2l-labs-accordion-toggle-focus');
+		this.fire('d2l-labs-accordion-collapse-toggle-focus');
 	},
 	_triggerBlur: function() {
-		this.fire('d2l-labs-accordion-toggle-blur');
+		this.fire('d2l-labs-accordion-collapse-toggle-blur');
 	},
 	_handleTransitionChanged(event) {
 

--- a/accordion-collapse.js
+++ b/accordion-collapse.js
@@ -85,9 +85,12 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-accordion-collapse">
 			:host([disabled]) d2l-icon {
 				color: var(--d2l-color-chromite);
 			}
+			:host([disable-default-trigger-focus]) #trigger:focus {
+				outline: none;
+			}
 		</style>
 
-		<a href="javascript:void(0)" id="trigger" on-click="toggle" aria-controls="collapse" role="button" data-border$="[[headerBorder]]">
+		<a href="javascript:void(0)" id="trigger" on-click="toggle" aria-controls="collapse" role="button" data-border$="[[headerBorder]]" on-focus="_triggerFocus" on-blur="_triggerBlur">
 			<div class="collapse-title" title="[[label]]">[[title]][[label]]<slot name="header"></slot>
 			</div>
 			<template is="dom-if" if="[[!noIcons]]">
@@ -211,7 +214,15 @@ Polymer({
 			type: String,
 			reflectToAttribute: true,
 			value: 'closed'
-		}
+		},
+		/**
+		 * Whether or not to disable default focus styles
+		 */
+		disableDefaultTriggerFocus: {
+			type: Boolean,
+			reflectToAttribute: true,
+			value: false
+		},
 	},
 	ready: function() {
 		this._boundListener = this._onStateChanged.bind(this);
@@ -265,6 +276,12 @@ Polymer({
 		} else {
 			this.open();
 		}
+	},
+	_triggerFocus: function() {
+		this.fire('d2l-labs-accordion-toggle-focus');
+	},
+	_triggerBlur: function() {
+		this.fire('d2l-labs-accordion-toggle-blur');
 	},
 	_handleTransitionChanged(event) {
 


### PR DESCRIPTION
As part of [LX sidebar redesign](https://xd.adobe.com/view/e16d4c3f-77f8-4632-6a01-a98beb7c5072-975c/screen/2fc07bba-3928-4455-a3c2-589589994d8d/Specs-Navigation-Button-States?x_product=cc-slack%2F1.5.0) we wanted to capture focus of the accordion trigger and style it accordingly when focused.  Since this component is used in a variety of different areas with different styling (background colors specifically) in the header there was no clean way of setting a definite focus state for all use-cases. Instead, I did the following:

- Added `disable-default-trigger-focus` property so the default outline added by browsers is removed on focus. This allows custom styles to be added on focus without the lingering outline added by browsers
- Emit focus and blur events so the parent component can track when the trigger is focused and can style the component accordingly

An example of me using this implementation can be found [here](https://github.com/BrightspaceHypermediaComponents/sequences/commit/34dd93a3c7c150c495048bb2aec046f8f464ef90). 

Open to improvements or suggestions!