### PR TITLE
Flex add overflow hidden

### DIFF
--- a/accordion-collapse.js
+++ b/accordion-collapse.js
@@ -28,6 +28,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-accordion-collapse">
 			}
 			:host([flex]) .collapse-title {
 				@apply --layout-flex;
+				overflow: hidden;
 			}
 			:host([icon-has-padding]) d2l-icon {
 				padding-left: 1.25rem;

--- a/demo/accordion-collapse.html
+++ b/demo/accordion-collapse.html
@@ -143,5 +143,12 @@
 				</template>
 			</d2l-demo-snippet>
 		</d2l-demo-page>
+		<d2l-demo-snippet>
+			<template>
+				<d2l-labs-accordion-collapse label="FLEXLoremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididuntutlaboreetdoloremagnaaliquaUtenimadminimveniamquisnostrudexercitationullamcolaborisnisiutaliquipexeacommodoconsequatDuisauteiruredolorinreprehenderitinvoluptatevelitessecillumdoloreeufugiatnullapariaturExcepteursintoccaecatcupidatatnonproidentsuntinculpaquiofficiadeseruntmollitanimidestlaborum" flex icon-has-padding>
+					Demo
+				</d2l-labs-accordion-collapse>
+			</template>
+		</d2l-demo-snippet>
 	</body>
 </html>


### PR DESCRIPTION
Otherwise the text goes outside of the limit of the container it's in.

--> This is intended to fix an issue with awards leaderboard

![image](https://user-images.githubusercontent.com/17279735/93619932-3dce3400-f9a7-11ea-95b7-521849d7e224.png)
