### PR TITLE
Add 3px padding on trigger to increase contrast

### DIFF
--- a/accordion-collapse.js
+++ b/accordion-collapse.js
@@ -18,6 +18,9 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-accordion-collapse">
 				@apply --layout-center;
 				text-decoration: none;
 			}
+			#trigger:focus-visible {
+				outline-offset: 3px;
+			}
 			#trigger[data-border] {
 				border-bottom: solid 1px var(--d2l-color-corundum);
 				margin-bottom: 0.4rem;


### PR DESCRIPTION
## Relevant Jira Links

[PHNX-1929](https://desire2learn.atlassian.net/browse/PHNX-1929)


## Description

The focus indicator that appears as an outline on the accordions in the New Learner Experience when navigating the page with a keyboard results in low contrast. The requested solution is either increase the padding between the accordion and the focus border or change the focus border colour to meet the acceptable contrast ratio.


## Goal/Solution

Increasing the padding was the greenlit solution, and 3px was the recommended length by our designer. The change was made specifically on `focus-visible` element state activation for accessibility and UX purposes, as this will only trigger when the component is focused and visible.

## Screenshots/Demo
Before
![image](https://github.com/BrightspaceUILabs/accordion/assets/85323237/9265d927-8b74-4456-9b39-24bbbb7a9f62)
After
![image_720](https://github.com/BrightspaceUILabs/accordion/assets/85323237/d57195ab-2ef5-4e90-9b1a-4a359b75365b)


[PHNX-1929]: https://desire2learn.atlassian.net/browse/PHNX-1929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ