### PR TITLE
[KAIJU 58] - Update Accordion to Account for Clickable Elements in Header

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ npm install @brightspace-ui-labs/accordion
 * icon-has-padding - adds padding on one side of the icon.
   * When used with 'flex' attribute, the padding will be to the right. (Opposite for RTL)
   * Without 'flex' attribute, the padding will be on the left. (Opposite for RTL)
-* header-has-clickable - adjusts the html to allow clickable elements in the header to function properly
+* header-has-interactive-content - adjusts the html to allow interactive (e.g. clickable) elements in the header to function properly
 (especially with screen readers)
-  * If this is true, any clickable elements being slotted through the `header` must have a `z-index` of at
-	least 1 in order to be clickable (see Example 6)
+  * If this is true, any interactive elements being slotted through the `header` must have a `z-index` of at
+	least 1 in order to be interactable (see Example 6)
 * screen-reader-header-text - text that is visually hidden and only used for a screen reader to read text
 from the header
 
@@ -112,7 +112,7 @@ Example 5:
 
 Example 6:
 ```html
-<d2l-labs-accordion-collapse header-has-clickable screen-reader-header-text="Go to D2L">
+<d2l-labs-accordion-collapse header-has-interactive-content screen-reader-header-text="Go to D2L">
 	<span slot="header">
 		Go to
 		<a href="https://www.d2l.com/" style="position: relative; z-index: 1;">D2L</a>

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ npm install @brightspace-ui-labs/accordion
   * Without 'flex' attribute, the padding will be on the left. (Opposite for RTL)
 * header-has-clickable - adjusts the html to allow clickable elements in the header to function properly
 (especially with screen readers)
+  * If this is true, any clickable elements being slotted through the `header` must have a `z-index` of at
+	least 1 in order to be clickable (see Example 6)
 * screen-reader-header-text - text that is visually hidden and only used for a screen reader to read text
 from the header
 
@@ -105,6 +107,16 @@ Example 5:
 		<li>Special access</li>
 	</ul>
 	<p>Stuff inside of the accordion goes here</p>
+</d2l-labs-accordion-collapse>
+```
+
+Example 6:
+```html
+<d2l-labs-accordion-collapse header-has-clickable screen-reader-header-text="Go to D2L">
+	<span slot="header">
+		Go to
+		<a href="https://www.d2l.com/" style="position: relative; z-index: 1;">D2L</a>
+	</span>
 </d2l-labs-accordion-collapse>
 ```
 ## Developing and Contributing

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ npm install @brightspace-ui-labs/accordion
   * Without 'flex' attribute, the padding will be on the left. (Opposite for RTL)
 * header-has-interactive-content - adjusts the html to allow interactive (e.g. clickable) elements in the header to function properly
 (especially with screen readers)
-  * If this is true, any interactive elements being slotted through the `header` must have a `z-index` of at
-	least 1 in order to be interactable (see Example 6)
 * screen-reader-header-text - text that is visually hidden and only used for a screen reader to read text
 from the header
 
@@ -115,7 +113,7 @@ Example 6:
 <d2l-labs-accordion-collapse header-has-interactive-content screen-reader-header-text="Go to D2L">
 	<span slot="header">
 		Go to
-		<a href="https://www.d2l.com/" style="position: relative; z-index: 1;">D2L</a>
+		<a href="https://www.d2l.com/">D2L</a>
 	</span>
 </d2l-labs-accordion-collapse>
 ```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ npm install @brightspace-ui-labs/accordion
 * icon-has-padding - adds padding on one side of the icon.
   * When used with 'flex' attribute, the padding will be to the right. (Opposite for RTL)
   * Without 'flex' attribute, the padding will be on the left. (Opposite for RTL)
+* header-has-clickable - adjusts the html to allow clickable elements in the header to function properly
+(especially with screen readers)
+* screen-reader-header-text - text that is visually hidden and only used for a screen reader to read text
+from the header
 
 #### Slots:
 * header - content to display under the title
@@ -137,4 +141,4 @@ npm start
 
 This repo is configured to use `semantic-release`. Commits prefixed with `fix:` and `feat:` will trigger patch and minor releases when merged to `main`.
 
-To learn how to create major releases and release from maintenance branches, refer to the [semantic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/main/semantic-release) documentation. 
+To learn how to create major releases and release from maintenance branches, refer to the [semantic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/main/semantic-release) documentation.

--- a/accordion-collapse.js
+++ b/accordion-collapse.js
@@ -100,20 +100,23 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-accordion-collapse">
 		</style>
 		<template is="dom-if" if="[[headerHasInteractiveContent]]">
 			<style>
-				#header-container{
-					position: relative;
+				#header-container {
+					display: grid;
+					grid-template-columns: auto;
+					grid-template-rows: auto;
 				}
-				#trigger {
-					position: absolute;
-					width: 100%;
-					height: 100%;
-					z-index: 1;
+				.header-grid-item {
+					grid-column: 1;
+					grid-row: 1;
+				}
+				#interactive-header-content {
+					cursor: pointer;
 				}
 			</style>
 		</template>
 
 		<div id="header-container">
-			<a href="javascript:void(0)" id="trigger" aria-controls="collapse" role="button" data-border$="[[headerBorder]]" on-blur="_triggerBlur" on-click="toggle" on-focus="_triggerFocus">
+			<a href="javascript:void(0)" id="trigger" class="header-grid-item" aria-controls="collapse" role="button" data-border$="[[headerBorder]]" on-blur="_triggerBlur" on-click="toggle" on-focus="_triggerFocus">
 				<template is="dom-if" if="[[!headerHasInteractiveContent]]">
 					<div class="collapse-title" title="[[label]]">[[title]][[label]]<slot name="header"></slot>
 					</div>
@@ -126,7 +129,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-accordion-collapse">
 				</template>
 			</a>
 			<template is="dom-if" if="[[headerHasInteractiveContent]]">
-				<div id="interactive-header-content">
+				<div id="interactive-header-content" class="header-grid-item" on-click="toggle">
 					<div class="collapse-title" title="[[label]]">[[title]][[label]]<slot name="header"></slot>
 					</div>
 					<template is="dom-if" if="[[!noIcons]]">

--- a/accordion-collapse.js
+++ b/accordion-collapse.js
@@ -14,7 +14,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-accordion-collapse">
 			:host {
 				display: block;
 			}
-			#div-trigger{
+			#clickable-header-content{
 				@apply --layout-horizontal;
 				@apply --layout-center;
 			}
@@ -103,11 +103,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-accordion-collapse">
 				#header-container{
 					position: relative;
 				}
-				#div-trigger{
-					position: relative;
-					z-index: 2;
-					cursor: pointer;
-				}
 				#trigger {
 					position: absolute;
 					width: 100%;
@@ -131,7 +126,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-accordion-collapse">
 				</template>
 			</a>
 			<template is="dom-if" if="[[headerHasClickable]]">
-				<div id="div-trigger" on-click="toggle">
+				<div id="clickable-header-content">
 					<div class="collapse-title" title="[[label]]">[[title]][[label]]<slot name="header"></slot>
 					</div>
 					<template is="dom-if" if="[[!noIcons]]">

--- a/accordion-collapse.js
+++ b/accordion-collapse.js
@@ -14,7 +14,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-accordion-collapse">
 			:host {
 				display: block;
 			}
-			#clickable-header-content{
+			#interactive-header-content{
 				@apply --layout-horizontal;
 				@apply --layout-center;
 			}
@@ -98,7 +98,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-accordion-collapse">
 				outline: none;
 			}
 		</style>
-		<template is="dom-if" if="[[headerHasClickable]]">
+		<template is="dom-if" if="[[headerHasInteractiveContent]]">
 			<style>
 				#header-container{
 					position: relative;
@@ -114,19 +114,19 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-labs-accordion-collapse">
 
 		<div id="header-container">
 			<a href="javascript:void(0)" id="trigger" aria-controls="collapse" role="button" data-border$="[[headerBorder]]" on-blur="_triggerBlur" on-click="toggle" on-focus="_triggerFocus">
-				<template is="dom-if" if="[[!headerHasClickable]]">
+				<template is="dom-if" if="[[!headerHasInteractiveContent]]">
 					<div class="collapse-title" title="[[label]]">[[title]][[label]]<slot name="header"></slot>
 					</div>
 					<template is="dom-if" if="[[!noIcons]]">
 						<d2l-icon icon="[[_toggle(opened, collapseIcon, expandIcon)]]"></d2l-icon>
 					</template>
 				</template>
-				<template is="dom-if" if="[[headerHasClickable]]">
+				<template is="dom-if" if="[[headerHasInteractiveContent]]">
 					<span class="d2l-offscreen">[[screenReaderHeaderText]]</span>
 				</template>
 			</a>
-			<template is="dom-if" if="[[headerHasClickable]]">
-				<div id="clickable-header-content">
+			<template is="dom-if" if="[[headerHasInteractiveContent]]">
+				<div id="interactive-header-content">
 					<div class="collapse-title" title="[[label]]">[[title]][[label]]<slot name="header"></slot>
 					</div>
 					<template is="dom-if" if="[[!noIcons]]">
@@ -256,9 +256,9 @@ Polymer({
 			value: false
 		},
 		/**
-		 * Whether or not the header contains a clickable element inside it
+		 * Whether or not the header contains an interactive element inside it (e.g. clickable)
 		 */
-		headerHasClickable: {
+		headerHasInteractiveContent: {
 			type: Boolean,
 			value: false
 		},

--- a/demo/index.html
+++ b/demo/index.html
@@ -111,7 +111,7 @@
 						>
 							<span slot="header">
 								Go to
-								<a href="https://www.d2l.com/" onclick="event.stopPropagation();">D2L</a>
+								<a href="https://www.d2l.com/" style="position: relative; z-index: 1;">D2L</a>
 							</span>
 							Demo
 						</d2l-labs-accordion-collapse>

--- a/demo/index.html
+++ b/demo/index.html
@@ -111,7 +111,7 @@
 						>
 							<span slot="header">
 								Go to
-								<a href="https://www.d2l.com/" style="position: relative; z-index: 1;">D2L</a>
+								<a href="https://www.d2l.com/">D2L</a>
 							</span>
 							Demo
 						</d2l-labs-accordion-collapse>

--- a/demo/index.html
+++ b/demo/index.html
@@ -100,6 +100,24 @@
 					</d2l-labs-accordion>
 				</template>
 			</d2l-demo-snippet>
+
+			<h3>Clickable Header</h3>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-labs-accordion>
+						<d2l-labs-accordion-collapse
+							header-has-clickable
+							screen-reader-header-text="Go to D2L"
+						>
+							<span slot="header">
+								Go to
+								<a href="https://www.d2l.com/" onclick="event.stopPropagation();">D2L</a>
+							</span>
+							Demo
+						</d2l-labs-accordion-collapse>
+					</d2l-labs-accordion>
+				</template>
+			</d2l-demo-snippet>
 		</d2l-demo-page>
 	</body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -106,7 +106,7 @@
 				<template>
 					<d2l-labs-accordion>
 						<d2l-labs-accordion-collapse
-							header-has-clickable
+							header-has-interactive-content
 							screen-reader-header-text="Go to D2L"
 						>
 							<span slot="header">


### PR DESCRIPTION
Related JIRA Ticket: https://desire2learn.atlassian.net/jira/software/c/projects/KAIJU/boards/648?selectedIssue=KAIJU-58

### Description

This PR includes changes to enable clickable elements (e.g. links) in headers to function properly. 

This seemed to be a use case that was unaccounted for, as if a clickable element like a link was slotted in via the `headers` slot, it would simply be nested inside the `trigger` anchor tag. Nesting anchor tags are considered bad practice and it makes it difficult for screen readers to determine which anchor tag to trigger. 

### Solution
- Added an attribute called `headerHasClickable` to determine when a header has a clickable element
- All existing functionality and html structure is kept the same if `headerHasClickable` is false
- When `headerHasClickable` is true, the `triggger` anchor tag has no content and is positioned absolute on top of a `div` with id `clickable-header-content` which contains the header content
  - This is to decouple the anchor tag with any content sent through the `header` slot and prevents them being nested
    - Note that any clickable elements sent through the `header` slot must have a `z-index` of at least 1 in order to be positioned on top of `trigger` and be clickable
  - A `span` tag is introduced as a child of `trigger` which uses a newly added attribute `screenReaderHeaderText` and `offscreenStyles` to hide it visually, but enable a screen reader to read the header's content

This solution was inspired by what's done with `d2l-card`:
![image](https://github.com/user-attachments/assets/af7faef6-d195-443f-ada0-8933ea870f00)


### Before (with sound):

https://github.com/user-attachments/assets/f3f0ab61-1bf7-425d-ae27-8722b1464e66

- Note that clicking works fine
- Note that JAWS was able to tab to the link, but unable to trigger it (it triggered the expand/collapse instead)

### After (with sound):

https://github.com/user-attachments/assets/763c9d78-e888-4192-8a51-b180a432e4b0

- Clicking works as before
- JAWS is now able to tab to the link and when enter is pressed, triggers the link and goes to the corresponding page